### PR TITLE
upgrade mvn dependency for pacx

### DIFF
--- a/java/connector-node/risingwave-sink-deltalake/pom.xml
+++ b/java/connector-node/risingwave-sink-deltalake/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <parquet.version>1.12.3</parquet.version>
+        <parquet.version>1.14.0</parquet.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 

--- a/java/connector-node/risingwave-sink-iceberg/pom.xml
+++ b/java/connector-node/risingwave-sink-iceberg/pom.xml
@@ -16,7 +16,7 @@
     <name>risingwave-sink-iceberg</name>
 
     <properties>
-        <iceberg.version>1.4.1</iceberg.version>
+        <iceberg.version>1.5.2</iceberg.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <protobuf.version>3.21.1</protobuf.version>
-        <grpc.version>1.53.0</grpc.version>
+        <grpc.version>1.64.0</grpc.version>
         <gson.version>2.10</gson.version>
         <module.version>0.1.0-SNAPSHOT</module.version>
         <spotless.version>2.43.0</spotless.version>
@@ -74,12 +74,12 @@
         <commons.io.version>2.11.0</commons.io.version>
         <commons.text.version>1.10.0</commons.text.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
-        <debezium.version>2.4.2.Final</debezium.version>
+        <debezium.version>2.6.2.Final</debezium.version>
         <jackson.version>2.13.5</jackson.version>
         <spark_sql.version>3.3.1</spark_sql.version>
-        <hadoop.version>3.3.3</hadoop.version>
+        <hadoop.version>3.4.0</hadoop.version>
         <elasticsearch.version>7.17.19</elasticsearch.version>
-        <datastax.version>4.15.0</datastax.version>
+        <datastax.version>4.17.0</datastax.version>
         <flink.version>1.18.0</flink.version>
         <testcontainers.version>1.17.6</testcontainers.version>
         <postgresql.version>42.5.5</postgresql.version>
@@ -87,7 +87,7 @@
         <mongodb.driver.sync.version>4.11.1</mongodb.driver.sync.version>
         <sqlite.version>3.45.0.0</sqlite.version>
         <aws.version>2.21.42</aws.version>
-        <hive.version>3.1.3</hive.version>
+        <hive.version>4.0.0</hive.version>
     </properties>
 
     <dependencyManagement>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -80,7 +80,7 @@
         <hadoop.version>3.4.0</hadoop.version>
         <elasticsearch.version>7.17.19</elasticsearch.version>
         <datastax.version>4.17.0</datastax.version>
-        <flink.version>1.18.0</flink.version>
+        <flink.version>1.19.1</flink.version>
         <testcontainers.version>1.17.6</testcontainers.version>
         <postgresql.version>42.5.5</postgresql.version>
         <mysql.connector.java.version>8.3.0</mysql.connector.java.version>


### PR DESCRIPTION
To address the security vulnerabilities discovered by the PACX security team,  it has upgraded the corresponding Maven dependencies to the newest versions.